### PR TITLE
Add sf3 compat for expression language

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4",
         "symfony/monolog-bundle": "2.*",
-        "symfony/expression-language": "~2.3"
+        "symfony/expression-language": "~2.3|~3.0"
     },
     "require-dev": {
         "atoum/atoum": "dev-master",

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     },
     "require-dev": {
         "atoum/atoum": "dev-master",
-        "symfony/yaml": "~2.3"
+        "symfony/yaml": "~2.3|~3.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }


### PR DESCRIPTION
Sf3 requires symfony/expression-language ~3.0 https://github.com/symfony/symfony/blob/master/composer.json#L44