### PR TITLE
add expression-language 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,4 +1,3 @@
-
 {
     "name": "m6web/monolog-extra-bundle",
     "type": "symfony-bundle",
@@ -16,11 +15,11 @@
     "require": {
         "php": ">=5.6",
         "symfony/monolog-bundle": "~2.0 || ~3.0",
-        "symfony/expression-language": "~2.3 || ~3.0"
+        "symfony/expression-language": "~2.3 || ~3.0 || ~4.0"
     },
     "require-dev": {
         "atoum/atoum": "~3.0",
-        "symfony/yaml": "~2.3 || ~3.0"
+        "symfony/yaml": "~2.3 || ~3.0 || ~4.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }

--- a/src/M6Web/Bundle/MonologExtraBundle/DependencyInjection/M6WebMonologExtraExtension.php
+++ b/src/M6Web/Bundle/MonologExtraBundle/DependencyInjection/M6WebMonologExtraExtension.php
@@ -38,7 +38,7 @@ class M6WebMonologExtraExtension extends Extension
                     $tagOptions['handler'] = $processor['handler'];
                 }
 
-                $definition = clone $container->getDefinition(sprintf('%s.processor.%s', $alias, $processor['type']));
+                $definition = clone $container->getDefinition(sprintf('%s.processor.%s', $alias, lcfirst($processor['type'])));
                 $definition->setAbstract(false);
                 $definition->addtag('monolog.processor', $tagOptions);
 


### PR DESCRIPTION
add expression-language 4

Edit:

In the conf you can
```yml
m6_web_monolog_extra:
    processors:
        myProcessor:
            type: ContextInformation
```

It used to look for `m6_web_monolog_extra.processor.ContextInformation` but it can not find it anymore because it is now case sensitive. It needs `m6_web_monolog_extra.processor.contextInformation`