### PR TITLE
feat(symfony): add Symfony 5 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,9 @@
 
 Provide extra features for Monolog.
 
+The actual version of this bundle support `Symfony >= 4.4`.
+If you need support for older versions, you have to use version `< 3.0`.
+
 ## Installation
 
 Via composer :

--- a/composer.json
+++ b/composer.json
@@ -15,11 +15,11 @@
     "require": {
         "php": ">=5.6",
         "symfony/monolog-bundle": "~2.0 || ~3.0",
-        "symfony/expression-language": "~2.3 || ~3.0 || ~4.0"
+        "symfony/expression-language": "~4.2 || ~5.0"
     },
     "require-dev": {
         "atoum/atoum": "~3.0",
-        "symfony/yaml": "~2.3 || ~3.0 || ~4.0"
+        "symfony/yaml": "~4.2 || ~5.0"
     },
     "autoload": {
         "psr-0": { "": "src/" }

--- a/src/M6Web/Bundle/MonologExtraBundle/DependencyInjection/Configuration.php
+++ b/src/M6Web/Bundle/MonologExtraBundle/DependencyInjection/Configuration.php
@@ -15,8 +15,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('m6_web_monolog_extra');
+        $treeBuilder = new TreeBuilder('m6_web_monolog_extra');
+        $rootNode = $treeBuilder->getRootNode();
 
         $rootNode
             ->children()


### PR DESCRIPTION
This PR add Symfony 5.x compatibility to this bundle.

⚠️ Because of a breaking change related to `symfony/config` component, I dropped support for Symfony < 4.2.